### PR TITLE
chore: save copy-paste report in its own subfolder within target/

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,5 +1,5 @@
 {
-  "output": "./target",
+  "output": "./target/copy-paste-report",
   "minLines": 3,
   "threshold": 0.1,
   "reporters": ["html", "console"],


### PR DESCRIPTION
Currently jscpd just write the report to `target/html` which is not obvious to find and mind conflict with other tools.