### PR TITLE
Recognize configuration values if optional CLI arguments are undefined

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "3.1.1",
             "license": "MIT",
             "dependencies": {
+                "@commander-js/extra-typings": "12.1.0",
                 "@sindresorhus/is": "7.0.1",
                 "commander": "12.1.0",
                 "cosmiconfig": "9.0.0",
@@ -236,6 +237,14 @@
             "optional": true,
             "engines": {
                 "node": ">=0.1.90"
+            }
+        },
+        "node_modules/@commander-js/extra-typings": {
+            "version": "12.1.0",
+            "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-12.1.0.tgz",
+            "integrity": "sha512-wf/lwQvWAA0goIghcb91dQYpkLBcyhOhQNqG/VgWhnKzgt+UOMvra7EX/2fv70arm5RW+PUHoQHHDa6/p77Eqg==",
+            "peerDependencies": {
+                "commander": "~12.1.0"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "release": "release-it"
     },
     "dependencies": {
+        "@commander-js/extra-typings": "12.1.0",
         "@sindresorhus/is": "7.0.1",
         "commander": "12.1.0",
         "cosmiconfig": "9.0.0",

--- a/source/bin.tsx
+++ b/source/bin.tsx
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import React from 'react';
-import { createCommand } from 'commander';
+import { createCommand } from '@commander-js/extra-typings';
 import { render } from 'ink';
 import { cosmiconfig } from 'cosmiconfig';
 import path from 'node:path';
@@ -10,7 +10,6 @@ import { Error } from './Error.js';
 import { deleteRequest, getRequest } from './network.js';
 import { deletePipeline, filterPipelinesByDate, listPipelines } from './gitlab.js';
 import { baseConfigSchema, loadConfig, mergeCliArgumentsWithConfig, PartialConfigInput } from './config.js';
-import is from '@sindresorhus/is';
 
 function exit() {
     process.exitCode = 1;
@@ -24,68 +23,65 @@ program
     .arguments('[gitlab-url]')
     .arguments('[project-id]')
     .arguments('[access-token]')
-    .option('-d --days <days>', `older than days  (default: "${baseConfigSchema.shape.days._def.defaultValue()}")`)
+    .option(
+        '-d --days <days>',
+        `older than days  (default: "${baseConfigSchema.shape.days._def.defaultValue()}")`,
+        (value: string) => parseInt(value, 10),
+    )
     .option(
         '--trace',
         `show stack traces for errors when possible (default: ${baseConfigSchema.shape.trace._def.defaultValue()})`,
     )
-    .action(
-        async (
-            gitlabUrlArgument: string | undefined,
-            projectIdArgument: string | undefined,
-            accessTokenArgument: string | undefined,
-            options: Record<string, unknown>,
-        ) => {
-            const cliArguments: PartialConfigInput = {
-                gitlabUrl: gitlabUrlArgument,
-                projectId: projectIdArgument,
-                accessToken: accessTokenArgument,
-                days: is.string(options.days) ? parseInt(options.days, 10) : undefined,
-                trace: is.boolean(options.trace) ? options.trace : undefined,
-            };
-            const configPath = path.resolve(process.cwd(), 'glpd.config.js');
-            const explorer = cosmiconfig('gitlab-pipeline-deleter');
-            const loadedConfig = await loadConfig(configPath, explorer);
-            const glpdArguments = loadedConfig.andThen((config) => {
-                return mergeCliArgumentsWithConfig(cliArguments, config);
-            });
+    .action(async (gitlabUrlArgument, projectIdArgument, accessTokenArgument, options) => {
+        const cliArguments: PartialConfigInput = {
+            gitlabUrl: gitlabUrlArgument,
+            projectId: projectIdArgument,
+            accessToken: accessTokenArgument,
+            days: options.days,
+            trace: options.trace,
+        };
+        const configPath = path.resolve(process.cwd(), 'glpd.config.js');
+        const explorer = cosmiconfig('gitlab-pipeline-deleter');
+        const loadedConfig = await loadConfig(configPath, explorer);
+        const glpdArguments = loadedConfig.andThen((config) => {
+            return mergeCliArgumentsWithConfig(cliArguments, config);
+        });
 
-            if (glpdArguments.isErr) {
-                render(<Error exit={exit}>Missing or invalid arguments</Error>);
-                return;
-            }
+        if (glpdArguments.isErr) {
+            render(<Error exit={exit}>Missing or invalid arguments</Error>);
+            return;
+        }
 
-            const { gitlabUrl, projectIds, accessToken, days, trace } = glpdArguments.value;
-            const startDate = new Date();
-            const listPipelinesFunction = listPipelines({
-                getRequest,
-                gitlabUrl: gitlabUrl,
-                accessToken: accessToken,
-            });
-            const deletePipelineFunction = deletePipeline({
-                deleteRequest,
-                gitlabUrl: gitlabUrl,
-                accessToken: accessToken,
-            });
-            const deleteQueue = new PQueue({ autoStart: false, interval: 1000, intervalCap: 10 });
+        const { gitlabUrl, projectIds, accessToken, days, trace } = glpdArguments.value;
+        const startDate = new Date();
+        const listPipelinesFunction = listPipelines({
+            getRequest,
+            gitlabUrl: gitlabUrl,
+            accessToken: accessToken,
+        });
+        const deletePipelineFunction = deletePipeline({
+            deleteRequest,
+            gitlabUrl: gitlabUrl,
+            accessToken: accessToken,
+        });
+        const deleteQueue = new PQueue({ autoStart: false, interval: 1000, intervalCap: 10 });
 
-            render(
-                <App
-                    gitlabUrl={gitlabUrl}
-                    projectIds={projectIds}
-                    accessToken={accessToken}
-                    days={days}
-                    startDate={startDate}
-                    exit={exit}
-                    listPipelines={listPipelinesFunction}
-                    filterPipelinesByDate={filterPipelinesByDate}
-                    deletePipeline={deletePipelineFunction}
-                    deleteQueue={deleteQueue}
-                    showStackTraces={trace}
-                />,
-            );
-        },
-    );
+        render(
+            <App
+                gitlabUrl={gitlabUrl}
+                projectIds={projectIds}
+                accessToken={accessToken}
+                days={days}
+                startDate={startDate}
+                exit={exit}
+                listPipelines={listPipelinesFunction}
+                filterPipelinesByDate={filterPipelinesByDate}
+                deletePipeline={deletePipelineFunction}
+                deleteQueue={deleteQueue}
+                showStackTraces={trace}
+            />,
+        );
+    });
 
 function crash(error: Error) {
     console.error(error);

--- a/source/config.ts
+++ b/source/config.ts
@@ -3,11 +3,11 @@ import { Result } from 'true-myth';
 import is from '@sindresorhus/is';
 import { z } from 'zod';
 
-const baseConfigSchema = z.object({
+export const baseConfigSchema = z.object({
     gitlabUrl: z.string().url(),
     accessToken: z.string(),
-    days: z.number(),
-    trace: z.boolean(),
+    days: z.number().default(30),
+    trace: z.boolean().default(false),
 });
 
 const configSchema = baseConfigSchema.extend({

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -365,7 +365,7 @@ test('returns config file values when no CLI arguments are present', testMergeCl
     }),
 });
 
-test('prefers CLI aguments over configuration values', testMergeCliArgumentsMacro, {
+test('prefers CLI arguments over configuration values', testMergeCliArgumentsMacro, {
     cliArguments: partialConfigInputFactory.build({
         gitlabUrl: 'https://example.com',
         projectId: '1',

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -370,6 +370,7 @@ test('prefers CLI arguments over configuration values', testMergeCliArgumentsMac
         gitlabUrl: 'https://example.com',
         projectId: '1',
         accessToken: '0',
+        days: 31,
         trace: true,
     }),
     config: partialConfigInputFactory.build({
@@ -381,9 +382,49 @@ test('prefers CLI arguments over configuration values', testMergeCliArgumentsMac
     }),
     expectedConfig: {
         accessToken: '0',
-        days: 42,
+        days: 31,
         gitlabUrl: 'https://example.com',
         projectIds: [1],
         trace: true,
     },
 });
+
+test('recognizes configuration values if CLI arguments are undefined', testMergeCliArgumentsMacro, {
+    cliArguments: {},
+    config: partialConfigInputFactory.build({
+        gitlabUrl: 'https://example.com',
+        projectId: '1',
+        accessToken: '0',
+        days: 42,
+        trace: true,
+    }),
+    expectedConfig: {
+        gitlabUrl: 'https://example.com',
+        projectIds: [1],
+        accessToken: '0',
+        days: 42,
+        trace: true,
+    },
+});
+
+test(
+    'recognizes default values if optional configuration values and CLI arguments are both undefined',
+    testMergeCliArgumentsMacro,
+    {
+        cliArguments: {},
+        config: partialConfigInputFactory.build({
+            gitlabUrl: 'https://example.com',
+            projectId: '1',
+            accessToken: '0',
+            days: undefined,
+            trace: undefined,
+        }),
+        expectedConfig: {
+            gitlabUrl: 'https://example.com',
+            projectIds: [1],
+            accessToken: '0',
+            days: 30,
+            trace: false,
+        },
+    },
+);

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -381,7 +381,7 @@ test('prefers CLI arguments over configuration values', testMergeCliArgumentsMac
     }),
     expectedConfig: {
         accessToken: '0',
-        days: 30,
+        days: 42,
         gitlabUrl: 'https://example.com',
         projectIds: [1],
         trace: true,


### PR DESCRIPTION
### Environment

* Configuration file `config.glpd.js` is in place and contains all possible values
* Invocation without arguments: `npm run glpd`

### Current behavior

When an optional CLI argument is `undefined`, its default value is used. The value from the configuration file is ignored.

Example:
1. `config.glpd.js` says `days: 60`
2. `npm run glpd` is invoked without arguments
3. 30 days are used

### Expected behavior

The value from the configuration file is recognized when the CLI argument is `undefined`.

Example:
1. `config.glpd.js` says `days: 60`
2. `npm run glpd` is invoked without arguments
3. 60 days are used